### PR TITLE
ensure map/renderer disposed, remove unused field

### DIFF
--- a/core/src/main/java/org/jeo/map/Map.java
+++ b/core/src/main/java/org/jeo/map/Map.java
@@ -66,8 +66,6 @@ public class Map implements Disposable {
 
     Style style = new Style();
 
-    View view;
-
     List<Disposable> cleanup = new ArrayList<Disposable>(); 
     Set<Listener> callbacks = new LinkedHashSet<Listener>();
 
@@ -75,7 +73,6 @@ public class Map implements Disposable {
      * Creates a new empty map.
      */
     public Map() {
-        view = new View(this);
     }
 
     /**

--- a/nano/src/main/java/org/jeo/nano/FeatureHandler.java
+++ b/nano/src/main/java/org/jeo/nano/FeatureHandler.java
@@ -352,7 +352,12 @@ public class FeatureHandler extends Handler {
 
         Renderer renderer = rf.create(view, null);
         renderer.init(view, null);
-        renderer.render(bout);
+        try {
+            renderer.render(bout);
+        } finally {
+            mb.map().close();
+            renderer.close();
+        }
 
         return new Response(HTTP_OK, MIME_PNG, new ByteArrayInputStream(bout.toByteArray()));
     }

--- a/nano/src/main/java/org/jeo/nano/WMSHandler.java
+++ b/nano/src/main/java/org/jeo/nano/WMSHandler.java
@@ -75,20 +75,20 @@ public class WMSHandler extends OWSHandler {
             String mimeType, Filter filter) throws IOException {
         MapBuilder mb = new MapBuilder();
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
-
+        mb.bounds(bbox).crs(crs).size(width, height);
+        for (Dataset ds : dataSet) {
+            mb.layer(ds, filter);
+        }
+        for (Style s : styles) {
+            mb.style(s);
+        }
+        View view = mb.view();
+        Renderer renderer = factory.create(view, null);
+        renderer.init(view, null);
         try {
-            mb.bounds(bbox).crs(crs).size(width, height);
-            for (Dataset ds : dataSet) {
-                mb.layer(ds, filter);
-            }
-            for (Style s : styles) {
-                mb.style(s);
-            }
-            View view = mb.view();
-            Renderer renderer = factory.create(view, null);
-            renderer.init(view, null);
             renderer.render(bout);
         } finally {
+            renderer.close();
             mb.map().close();
         }
 

--- a/nano/src/test/java/org/jeo/nano/MockServer.java
+++ b/nano/src/test/java/org/jeo/nano/MockServer.java
@@ -365,6 +365,8 @@ public class MockServer {
         expectLastCall().anyTimes();
         png.render((OutputStream) anyObject());
         expectLastCall().anyTimes();
+        png.close();
+        expectLastCall().once();
 
         final RendererFactory rf = createMock(RendererFactory.class);
         expect(rf.getFormats()).andReturn(Arrays.asList("png","image/png")).anyTimes();

--- a/nano/src/test/java/org/jeo/nano/WMSHandlerTest.java
+++ b/nano/src/test/java/org/jeo/nano/WMSHandlerTest.java
@@ -168,6 +168,7 @@ public class WMSHandlerTest extends HandlerTestSupport {
                 assertEquals("image/png", format);
                 assertNotNull(filter);
                 called[0] = true;
+                super.render(f, dataSet, styles, crs, bbox, width, height, format, filter);
                 return null;
             }
 


### PR DESCRIPTION
noticed some sql connection leaks when exceptions occurred - this fixed them.

noticed a left-over view field, too
