### PR TITLE
some minor cli fixes/enhancements

### DIFF
--- a/cli/src/main/java/org/jeo/cli/cmd/InfoCmd.java
+++ b/cli/src/main/java/org/jeo/cli/cmd/InfoCmd.java
@@ -96,7 +96,7 @@ public class InfoCmd extends JeoCmd {
     }
 
     void print(Workspace workspace, JeoJSONWriter w, JeoCLI cli) throws IOException {
-        w.workspace(workspace);
+        w.workspace(workspace, true);
     }
 
     void print(Style style, JeoJSONWriter w, JeoCLI cli) throws IOException {

--- a/cli/src/main/java/org/jeo/cli/cmd/JeoCmd.java
+++ b/cli/src/main/java/org/jeo/cli/cmd/JeoCmd.java
@@ -58,7 +58,13 @@ public abstract class JeoCmd {
                 print(e, cli);
             }
             else {
-                cli.getConsole().println(e.getMessage());
+                Throwable t = e;
+                while (t != null) {
+                    if (t.getMessage() != null) {
+                        cli.getConsole().println(t.getMessage());
+                    }
+                    t = t.getCause();
+                }
             }
         }
         finally {

--- a/cli/src/test/java/org/jeo/cli/CLITestSupport.java
+++ b/cli/src/test/java/org/jeo/cli/CLITestSupport.java
@@ -34,6 +34,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import com.vividsolutions.jts.geom.Point;
+import org.jeo.proj.Proj;
 
 /**
  * Base test for CLI command tests.
@@ -60,7 +61,7 @@ public class CLITestSupport {
     public void setUpData() throws IOException {
         MemWorkspace mem = Memory.open();
         MemVector widgets = mem.create(Schema.build("cities")
-            .field("geometry", Point.class).field("name", String.class).schema());
+            .field("geometry", Point.class, Proj.EPSG_4326).field("name", String.class).schema());
 
         Cursor<Feature> c = widgets.cursor(new Query().append());
 

--- a/core/src/main/java/org/jeo/feature/SchemaBuilder.java
+++ b/core/src/main/java/org/jeo/feature/SchemaBuilder.java
@@ -54,6 +54,17 @@ public class SchemaBuilder {
     }
 
     /**
+     * Create a new SchemaBuilder initialized to the state of the provided
+     * schema not including any field properties.
+     *
+     * @param schema the non-null schema to copy
+     * @return a new SchemaBuilder
+     */
+    public static SchemaBuilder clone(Schema schema) {
+        return new SchemaBuilder(schema.name).uri(schema.uri).fields(schema.fields);
+    }
+
+    /**
      * Sets the namespace of the schema.
      * 
      * @param uri A namespace uri.
@@ -202,5 +213,15 @@ public class SchemaBuilder {
      */
     public Schema schema() {
         return new Schema(name, uri, fields);
+    }
+
+    /**
+     * Remove a field (by equality) from the Schema being built.
+     * 
+     * @param field the field to remove
+     * @return true if successfully removed
+     */
+    public boolean remove(Field field) {
+        return fields.remove(field);
     }
 }

--- a/core/src/main/java/org/jeo/json/JeoJSONWriter.java
+++ b/core/src/main/java/org/jeo/json/JeoJSONWriter.java
@@ -68,17 +68,35 @@ public class JeoJSONWriter extends GeoJSONWriter {
     }
 
     /**
-     * Encodes a workspace object.
+     * Encodes a workspace object but not it's Datasets.
      */
     public JeoJSONWriter workspace(Workspace ws) throws IOException {
+        return workspace(ws, false);
+    }
+
+    /**
+     * Encodes a workspace object and optionally, its Datasets.
+     *
+     * @param children if true, include the Datasets
+     */
+    public JeoJSONWriter workspace(Workspace ws, boolean children) throws IOException {
         object();
 
         key("type").value("workspace");
         key("driver").value(ws.getDriver().getName());
 
-        key("datasets").array();
+        key("datasets");
+        array();
         for (Handle<Dataset> ref : ws.list()) {
-            value(ref.getName());
+            if (children) {
+                try {
+                    dataset(ref.resolve());
+                } finally {
+                    ref.close();
+                }
+            } else {
+                value(ref.getName());
+            }
         }
         endArray();
 


### PR DESCRIPTION
ConvertCmd requires SRID if one cannot be found in the src file and
supports overwriting existing target. Move some of the validation
and setup code to before attempting creation of target to avoid
empty target

SchemaBuilder methods to support retyping/changing fields from an
existing

InfoCmd on workspace prints its datasets, too

JeoCmd logs nested exception messages
