### PR TITLE
uniform filter behavior on missing property

### DIFF
--- a/core/src/main/java/org/jeo/data/Query.java
+++ b/core/src/main/java/org/jeo/data/Query.java
@@ -16,9 +16,12 @@ package org.jeo.data;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
-
+import java.util.Set;
 import org.jeo.feature.Feature;
+import org.jeo.feature.Field;
+import org.jeo.feature.Schema;
 import org.jeo.filter.Filter;
 import org.jeo.filter.Filters;
 import org.jeo.filter.cql.CQL;
@@ -381,6 +384,16 @@ public class Query {
         }
 
         return count;
+    }
+
+    public Set<String> missingProperties(Schema schema) {
+        Set<String> queryProperties = (Set<String>) (filter == null ?
+                Collections.emptySet() : Filters.properties(filter));
+        List<Field> f = schema.getFields();
+        for (int i = 0, ii = f.size(); i < ii && !queryProperties.isEmpty(); i++) {
+            queryProperties.remove(f.get(i).getName());
+        }
+        return queryProperties;
     }
 
     @Override

--- a/core/src/main/java/org/jeo/filter/Comparison.java
+++ b/core/src/main/java/org/jeo/filter/Comparison.java
@@ -85,6 +85,12 @@ public class Comparison<T> extends Filter<T> {
             }
         }
 
+        // if either is NaN, shortcut here as Double.compareTo has different
+        // behavior than expected (adheres to Object.equals ordering)
+        if (isNaN(o1) || isNaN(o2)) {
+            return false;
+        }
+
         if (type == Type.EQUAL) {
             return o1 != null ? o1.equals(o2) : o2 == null;
         }
@@ -93,7 +99,7 @@ public class Comparison<T> extends Filter<T> {
         }
 
         if (o1 == null || o2 == null) {
-            throw new IllegalArgumentException("Unable to perform comparison on null operand(s)");
+            return false;
         }
 
         Comparable<Object> c1 = toComparable(o1);
@@ -112,6 +118,10 @@ public class Comparison<T> extends Filter<T> {
         default:
             throw new IllegalStateException();
         }
+    }
+
+    static boolean isNaN(Object o) {
+        return o instanceof Number && Double.isNaN(((Number)o).doubleValue());
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/jeo/filter/FilterVisitor.java
+++ b/core/src/main/java/org/jeo/filter/FilterVisitor.java
@@ -105,6 +105,7 @@ public class FilterVisitor {
     }
 
     public Object visit(Like<?> like, Object obj) {
+        like.getProperty().accept(this, obj);
         return obj;
     }
 
@@ -115,6 +116,7 @@ public class FilterVisitor {
     }
 
     public Object visit(Null<?> isNull, Object obj) {
+        isNull.getProp().accept(this, obj);
         return obj;
     }
 

--- a/core/src/main/java/org/jeo/filter/Filters.java
+++ b/core/src/main/java/org/jeo/filter/Filters.java
@@ -14,6 +14,9 @@
  */
 package org.jeo.filter;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Filter utility class.
  * 
@@ -46,5 +49,17 @@ public class Filters {
      */
     public static <T> Filter<T> none() {
         return new None<T>();
+    }
+
+    public static Set<String> properties(Filter<?> f) {
+        return (Set<String>) f.accept(new FilterVisitor() {
+
+            @Override
+            public Object visit(Property property, Object obj) {
+                ((HashSet) obj).add(property.getProperty());
+                return obj;
+            }
+
+        }, new HashSet());
     }
 }

--- a/core/src/main/java/org/jeo/filter/Math.java
+++ b/core/src/main/java/org/jeo/filter/Math.java
@@ -50,10 +50,16 @@ public class Math implements Expression {
         return right;
     }
 
+    double getValue(Expression e, Object obj) {
+        Object val = e.evaluate(obj);
+        // mask missing values as NaN
+        return val == null ? Double.NaN : ((Number) val).doubleValue();
+    }
+
     @Override
     public Object evaluate(Object obj) {
-        double n1 = ((Number) left.evaluate(obj)).doubleValue();
-        double n2 = ((Number) right.evaluate(obj)).doubleValue();
+        double n1 = getValue(left, obj);
+        double n2 = getValue(right, obj);
         Double res;
         switch (operator) {
             case ADD: res = n1 + n2; break;

--- a/core/src/main/java/org/jeo/filter/Spatial.java
+++ b/core/src/main/java/org/jeo/filter/Spatial.java
@@ -78,7 +78,7 @@ public class Spatial<T> extends Filter<T> {
 
     protected boolean compare(Object o1, Object o2, Number d) {
         if (o1 == null || o2 == null) {
-            throw new IllegalArgumentException("Unable to perform comparison on null operand(s)");
+            return false;
         }
 
         if (type == Type.BBOX) {

--- a/core/src/test/java/org/jeo/data/VectorApiTestBase.java
+++ b/core/src/test/java/org/jeo/data/VectorApiTestBase.java
@@ -177,8 +177,15 @@ public abstract class VectorApiTestBase {
         assertCovered(data.cursor(new Query().filter("STATE_NAME LIKE 'Calif%'")), "CA");
 
         // null
-        assertEquals(49, Cursors.size(data.cursor(new Query().filter("P_MALE IS NOT NULL"))));
-        assertEquals(0, Cursors.size(data.cursor(new Query().filter("P_MALE IS NULL"))));
+        assertCount(49, data, "P_MALE IS NOT NULL");
+        assertCount(0, data, "P_MALE IS NULL");
+
+        // missing properties
+        assertCount(0, data, "MISSING IS NULL");
+        assertCount(0, data, "MISSING > 5");
+        assertCount(0, data, "MISSING + 5 > 5");
+        assertCount(0, data, "EQUALS(MISSING, POINT(0 0))");
+        assertCount(49, data, "MISSING > 5 OR P_MALE IS NOT NULL");
     }
 
     @Test
@@ -219,6 +226,12 @@ public abstract class VectorApiTestBase {
         }
         assertTrue("expected empty set, found " + set, set.isEmpty());
         assertEquals(abbrs.length, count);
+    }
+
+    void assertCount(int expected, VectorDataset dataSet, String filter) throws IOException {
+        Query q = new Query().filter(filter);
+        assertEquals(expected, dataSet.count(q));
+        assertEquals(expected, Cursors.size(dataSet.cursor(q)));
     }
 
     String fidFor(VectorDataset dataset, String filter) throws IOException {


### PR DESCRIPTION
for math expressions, a missing property is a NaN
for filters, a missing property evaluates to false
- fix behavior in CQL filter including NaN handling in
  Comparison
- have sql drivers fall-back to CQL filtering on missing
  properties to avoid SQL errors
- test coverage
