### PR TITLE
Fix TilePyramid.bounds(Tile)

### DIFF
--- a/core/src/main/java/io/jeo/tile/TilePyramid.java
+++ b/core/src/main/java/io/jeo/tile/TilePyramid.java
@@ -210,7 +210,7 @@ public class TilePyramid {
             y = b.getMinY() + dy*(h - t.y());
         }
 
-        return new Bounds(x, x+dx, y, y+dx);
+        return new Bounds(x, x+dx, y, y+dy);
     }
 
     /**


### PR DESCRIPTION
This accidentally worked when the width and height of a tile was equal